### PR TITLE
Avoid GK memory leak

### DIFF
--- a/trusty_gatekeeper.h
+++ b/trusty_gatekeeper.h
@@ -35,6 +35,13 @@
 
 namespace gatekeeper {
 
+template <typename T>
+struct FreeDeleter {
+    inline void operator()(T* p) const {
+        free(p);
+    }
+};
+
 class TrustyGateKeeper : public GateKeeper {
 public:
     TrustyGateKeeper();
@@ -90,6 +97,10 @@ private:
 
     int num_mem_records_;
     UniquePtr<failure_record_t[]> mem_records_;
+
+    mutable UniquePtr<uint8_t, FreeDeleter<uint8_t>>
+            cached_auth_token_key_;
+    mutable size_t cached_auth_token_key_len_;
 };
 
 }


### PR DESCRIPTION
GetAuthTokenKey is intended to retain ownership of the returned key. To
follow this, we cache the result of speaking to keymaster.

Bug: 129768470
Bug: 140434850
Bug: 131618642

Change-Id: If6e9b3f45cb7ca0656d7f75ed1e005d4a9919a43
Signed-off-by: Huang Yang <yang.huang@intel.com>